### PR TITLE
Fixed the default argument in fetch_login_cookies

### DIFF
--- a/downkedin/login.py
+++ b/downkedin/login.py
@@ -12,7 +12,7 @@ HEADERS = {"user-agent": "Mozilla/5.0"}
 async def check_signed_in(session: aiohttp.ClientSession) -> bool:
     async with session.get(HOME_URL) as response:
         html = await response.text()
-        return True if ">Sign in</" not in html else False
+        return bool(">Sign in</" not in html)
 
 
 async def fetch_params(session: aiohttp.ClientSession) -> dict:

--- a/downkedin/login.py
+++ b/downkedin/login.py
@@ -46,7 +46,8 @@ async def fetch_params(session: aiohttp.ClientSession) -> dict:
     }
 
 
-async def fetch_login_cookies(session: aiohttp.ClientSession, data: dict = None) -> None:
+async def fetch_login_cookies(session: aiohttp.ClientSession,
+                              data: dict = None) -> None:
     url = urljoin(str(HOME_URL), "checkpoint/lg/login-submit")
     await session.post(url, data=data, headers=HEADERS)
     filtered = session.cookie_jar.filter_cookies(HOME_URL)

--- a/downkedin/login.py
+++ b/downkedin/login.py
@@ -46,7 +46,7 @@ async def fetch_params(session: aiohttp.ClientSession) -> dict:
     }
 
 
-async def fetch_login_cookies(session: aiohttp.ClientSession, data: dict = {}) -> None:
+async def fetch_login_cookies(session: aiohttp.ClientSession, data: dict = None) -> None:
     url = urljoin(str(HOME_URL), "checkpoint/lg/login-submit")
     await session.post(url, data=data, headers=HEADERS)
     filtered = session.cookie_jar.filter_cookies(HOME_URL)


### PR DESCRIPTION
Fixed the default argument in fetch_login_cookies data parameter to None initialization to make it safe as per the issue highlighted in **DeepSource:** https://deepsource.io/gh/tiagovla/downkedin/issue/PYL-W0102/occurrences